### PR TITLE
Fix: manage xsects for conduits with 'CUSTOM' shape

### DIFF
--- a/g_s_links.py
+++ b/g_s_links.py
@@ -100,7 +100,7 @@ def get_conduits_from_shapefile(conduits_raw):
                 else:
                     return int(xs_row[col])
         else:
-            if xs_row['Shape'] in ['IRREGULAR', 'STREET', 'CUSTOM']:
+            if xs_row['Shape'] in ['IRREGULAR', 'STREET']:
                 return ''
             else:
                 if pd.isna(xs_row[col]):


### PR DESCRIPTION
Hi!

I was having a problem with a conduit that had a CUSTOM shape and it had a shape curve name in the `Shp_Trnsct` column, but SWMM reported me this:
![imatge](https://github.com/Jannik-Schilling/generate_swmm_inp/assets/78911250/9a908ab4-7a56-4ae4-a730-f13ee5d2813a)

The shape curve name wasn't there. So I went to look at how SWMM does it and I saw that it wrote them like this:
```
C2   CUSTOM    0.315    SHAPE_DEMO    0.0    0.0    1    
```
So I looked into the code and saw that it put the shape curve name in the `Geom2` column but then it was overridden by this:
```py
xsections_df['Geom2'] = xsections_df.apply(lambda x: fill_empty_xsects(x, 'Geom2'), axis=1)
```

I don't know if this change I made is the optimal solution, but it works for my application. I thought it was a bug that was overlooked so I opened this pull request, but if I'm not seeing something and this is intentional please let me know as I'm not a SWMM expert by any means.

Thanks!