### PR TITLE
Drop Z_Coord column if use_z_bool=False

### DIFF
--- a/g_s_export_helpers.py
+++ b/g_s_export_helpers.py
@@ -354,6 +354,9 @@ def use_z_if_available(
                 df['Name'],
                 layer_name
             )
+        elif coords_nodes is not None:
+            if 'Z_Coord' in coords_nodes.columns:
+                coords_nodes.drop("Z_Coord", axis=1, inplace=True)
 
     else:  # points
         coords_df = coords['COORDINATES']['data']
@@ -366,6 +369,8 @@ def use_z_if_available(
                 layer_name
             )
             df['Elevation'] = elevation_with_z
+        else:
+            coords_df.drop("Z_Coord", axis=1, inplace=True)
 
     return df
 


### PR DESCRIPTION
Hi @Jannik-Schilling I was wondering why are you writing the z_coords to the INP file, because if I don't use it (with the `use_z_coord` to False) it writes NaN on each [COORDINATES] line, and it might cause problems with reading INP-files with some libraries/tools.

I get it for importing, using the elevation as a z coordinate, but on the export I personally don't think that it's a good idea.

Please let me know if the code is right or if I made some mistakes/missed something.

Thanks!