### PR TITLE
Write inp headers

### DIFF
--- a/g_s_export_helpers.py
+++ b/g_s_export_helpers.py
@@ -354,6 +354,9 @@ def use_z_if_available(
                 df['Name'],
                 layer_name
             )
+        elif coords_nodes is not None:
+            if 'Z_Coord' in coords_nodes.columns:
+                coords_nodes.drop("Z_Coord", axis=1, inplace=True)
 
     else:  # points
         coords_df = coords['COORDINATES']['data']
@@ -366,6 +369,8 @@ def use_z_if_available(
                 layer_name
             )
             df['Elevation'] = elevation_with_z
+        else:
+            coords_df.drop("Z_Coord", axis=1, inplace=True)
 
     return df
 

--- a/g_s_write_inp.py
+++ b/g_s_write_inp.py
@@ -91,7 +91,13 @@ def write_inp(
             if only_cols is not None:
                 print_df = print_df[only_cols]
             file1.write('['+section_name+']\n')
-            file1.write(print_df.to_string(header=False, index=False))
+            # Write column headers in SWMM style
+            if len(print_df.columns) > 0:
+                header_line = ';;' + ''.join(str(col).ljust(15) for col in print_df.columns)
+                file1.write(header_line + '\n')
+                file1.write(';;' + '-' * len(header_line) + '\n')
+            # Write data with left justification
+            file1.write(print_df.to_string(header=False, index=False, col_space=15, formatters={col: lambda x: str(x).ljust(15) for col in print_df.columns}))
             file1.write('\n')
             file1.write('\n')   
 


### PR DESCRIPTION
Hi @Jannik-Schilling 

I noticed that the INP that this plugins writes doesn't have the headers, and also it aligns the fields to the right.

This gave us some issues with reading the INP file, as we read it line by line and we were expecting the two "headers" lines.

This is just a proof of concept, I only did it for the `df_to_inp_section`, but I think it works fine and, if you want, I could make it for all the sections.

I noticed that the commit about the Z_Coord column sneaked into this PR, if you want me to make all the other sections I will open another pull request with only those commits. But if you have a better idea or prefer to do it yourself, feel free of course!

Thanks!